### PR TITLE
fixed uploadcomments

### DIFF
--- a/wordcloud/templates/wordcloud/uploadcomments.html
+++ b/wordcloud/templates/wordcloud/uploadcomments.html
@@ -5,6 +5,10 @@
     <title>Upload Comments</title>
 </head>
 <body>
+	{% if uploadstatus %}
+		<p><b>{{ uploadstatus }}</b></p>
+	{% endif %}
+	
     <form action="{% url 'uploadcomments' %}" method="POST" enctype="multipart/form-data">
         {% csrf_token %}
         <input type="file" name="csvfile" />


### PR DESCRIPTION
uploadcomments will not redirect to /wordcloud/ on success, instead it will show a message on /uploadcomments/ reading "Comments updated.".
The behaviour was changed because the session variables required to load the wordcloud weren't set before redirection. Also it's clearer this way.
uploadcomments takes a long time because of the console outputs, hopefully it doesn't take as long in production.