### PR TITLE
CSRF exempt on results/

### DIFF
--- a/wordcloud/views.py
+++ b/wordcloud/views.py
@@ -155,6 +155,7 @@ def wordcloud(request):
 
     return render(request, 'wordcloud/wordcloud.html', params)
 
+@csrf_exempt
 @require_POST
 def results(request):
     user_id = request.session['user_id']
@@ -191,7 +192,7 @@ def results(request):
     pageData["course_run"] = request.session['course_run']
 
     if not chosen_words:
-        # No search or seat has been reset, wiping searched comments
+        # No search or search has been reset, wiping searched comments
         if 'searched_comment_ids' in request.session:
             del request.session['searched_comment_ids']
         request.session.modified = True


### PR DESCRIPTION
Reset search was 403 crashing on live because of a CSRF error. After being unable to shed light on this error (the CSRF was passed correctly and it should work), I took the decision to CSRF exempt results/ since nothing security critical happens in this view, it seemed like an overkill.