### PR TITLE
Ensure CSRF cookie on results/

### DIFF
--- a/wordcloud/views.py
+++ b/wordcloud/views.py
@@ -93,7 +93,7 @@ def getWeeks(request):
             del request.session['week']
     return results
 
-@csrf_exempt
+@ensure_csrf_cookie
 @require_POST
 def ltilaunch(request):
     consumer_key = request.POST.get('oauth_consumer_key')


### PR DESCRIPTION
The CSRF error on reset search seems to come from the CSRF not being in the cookie. According to Django documentation this should solve the issue.